### PR TITLE
filesysStatusCheck:  implement method

### DIFF
--- a/files/schema/DownloadService.filesysStatusCheck.schema
+++ b/files/schema/DownloadService.filesysStatusCheck.schema
@@ -1,0 +1,10 @@
+{
+    "id"    : "DownloadService.filesysStatusCheck",
+    "type"  : "object",
+    "properties" : {
+        "path" : {
+            "type"     : "string",
+            "description" : "path for the filesystem to check"
+        }
+    }
+}

--- a/files/sysbus/com.webos.service.downloadmanager.api.json
+++ b/files/sysbus/com.webos.service.downloadmanager.api.json
@@ -15,6 +15,7 @@
         "com.webos.service.downloadmanager/downloadStatusQuery",
         "com.webos.service.downloadmanager/pauseDownload",
         "com.webos.service.downloadmanager/resumeDownload",
-        "com.webos.service.downloadmanager/upload"
+        "com.webos.service.downloadmanager/upload",
+        "com.webos.service.downloadmanager/filesysStatusCheck"
     ]
 }

--- a/src/DownloadManager.h
+++ b/src/DownloadManager.h
@@ -201,6 +201,7 @@ public:
     static bool cbListPendingDownloads(LSHandle * lshandle,LSMessage *msg,void * user_data);
     static bool cbGetAllHistory(LSHandle * lshandle,LSMessage *msg, void * user_data);
     static bool cbClearDownloadHistory(LSHandle * lshandle,LSMessage *msg,void * user_data);
+    static bool cbFsStatusCheck(LSHandle * lshandle,LSMessage *msg,void * user_data);
 
     void filesystemStatusCheck(const uint64_t& spaceFreeKB,const uint64_t& spaceTotalKB,bool * criticalAlertRaised = 0, bool * stopMarkReached = 0);
 

--- a/src/DownloadManager.h
+++ b/src/DownloadManager.h
@@ -203,7 +203,7 @@ public:
     static bool cbClearDownloadHistory(LSHandle * lshandle,LSMessage *msg,void * user_data);
     static bool cbFsStatusCheck(LSHandle * lshandle,LSMessage *msg,void * user_data);
 
-    void filesystemStatusCheck(const uint64_t& spaceFreeKB,const uint64_t& spaceTotalKB,bool * criticalAlertRaised = 0, bool * stopMarkReached = 0);
+    void filesystemStatusCheck(const uint64_t& spaceFreeKB,const uint64_t& spaceTotalKB,uint32_t *pctFullValue = 0, bool * stopMarkReached = 0);
 
     // upload specific
     static bool cbUpload(LSHandle* lshandle, LSMessage *message,void *user_data);


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>

Usage example:
```
root@pinephone:~# df -h
Filesystem                Size      Used Available Use% Mounted on
/dev/mmcblk0p2            1.6G      1.3G    231.0M  85% /
/dev/mmcblk0p1          129.8M    128.1M      1.7M  99% /boot
root@pinephone:~# luna-send -n 1 luna://com.palm.downloadmanager/filesysStatusCheck '{"path":"/boot"}'
{"subscribed":false,"returnValue":true,"alert":"limit"}
```

By default, "path" is "/media/internal". In my example, it would check "/".